### PR TITLE
No longer use removed MAGIT-DEFINE- macros

### DIFF
--- a/magit-push-remote.el
+++ b/magit-push-remote.el
@@ -338,7 +338,7 @@ that for older Git versions setting the upstream might not work."
                 (equal push-remote pull-remote))
       push-remote)))
 
-(magit-define-inserter push-remote-unpulled-commits (remote remote-branch)
+(defun magit-insert-push-remote-unpulled-commits (remote remote-branch)
   (when remote
     (apply #'magit-git-section
            'unpulled
@@ -356,11 +356,11 @@ that for older Git versions setting the upstream might not work."
            (append magit-git-log-options
                    (list (format "%s/%s..HEAD" remote remote-branch))))))
 
-(magit-define-inserter pull-remote-unmerged-commits (remote remote-branch)
+(defun magit-insert-pull-remote-unmerged-commits (remote remote-branch)
   (magit-insert-unpushed-commits-internal
    remote remote-branch "Unmerged commits:"))
 
-(magit-define-inserter push-remote-unpushed-commits (remote remote-branch)
+(defun magit-insert-push-remote-unpushed-commits (remote remote-branch)
   (magit-insert-unpushed-commits-internal
    remote remote-branch "Unpushed commits:"))
 

--- a/magit-push-remote.el
+++ b/magit-push-remote.el
@@ -109,7 +109,7 @@
 
 ;; REDEFINE `magit-push-tags' DEFINED IN `magit.el'.
 ;;
-(magit-define-command push-tags ()
+(defun magit-push-tags ()
   "Push tags to a remote repository.
 
 With a prefix argument or when the remote cannot be determined as
@@ -140,7 +140,7 @@ exists; or if only one remote is configured use that."
 
 ;; REDEFINE `magit-push' DEFINED IN `magit.el'.
 ;;
-(magit-define-command push ()
+(defun magit-push ()
   "Push the current branch to a remote repository.
 
 With a single prefix argument ask the user what branch to push to.


### PR DESCRIPTION
I tried to install magit-push-remote from MELPA, but I found that it uses two macros that were removed from magit.el.  These two commits replace the use of these macros by simple DEFUNs.

There are still a few compiler warnings left that point to other incompatibilities with magit.el.  Do you think it is worth for me to work on them?
